### PR TITLE
Fix inconsistent description of default number of workers

### DIFF
--- a/main.py
+++ b/main.py
@@ -32,7 +32,7 @@ def get_args_parser():
                             ' | '.join(model_names) +
                             ' (default: CRATE_tiny)')
     parser.add_argument('-j', '--workers', default=16, type=int, metavar='N',
-                        help='number of data loading workers (default: 4)')
+                        help='number of data loading workers (default: 16)')
     parser.add_argument('--epochs', default=90, type=int, metavar='N',
                         help='number of total epochs to run')
     parser.add_argument('--start-epoch', default=0, type=int, metavar='N',


### PR DESCRIPTION
Not sure which one was meant to be the correct one. Changing help message is definitely safer.